### PR TITLE
Provide \crefmultiformat definition

### DIFF
--- a/cryptocode.sty
+++ b/cryptocode.sty
@@ -499,6 +499,7 @@
 \makeatletter%
 \crefformat{@pclinenumber}{line~##2##1##3}%
 \crefrangeformat{@pclinenumber}{lines~##3##1##4 to~##5##2##6}%
+\crefmultiformat{@pclinenumber}{lines~##2##1##3}{ and~##2##1##3}{, ##2##1##3}{ and~##2##1##3}%
 \makeatother%
 }}
 \newcommand{\pchspace}[1][1em]{\hspace{#1}}


### PR DESCRIPTION
for multireferences such as \cref{a,b,c} which is then translated into "lines 1, 2, and 3"