### PR TITLE
Add xspace to adversary terms

### DIFF
--- a/cryptocode-2020-04-24.sty
+++ b/cryptocode-2020-04-24.sty
@@ -103,14 +103,14 @@
 \DeclareOption{adversary}{
 	\providecommand{\pcadvstyle}[1]{\mathcal{#1}}
 	
-	\providecommand{\adv}{\ensuremath{\pcadvstyle{A}}}
-	\providecommand{\bdv}{\ensuremath{\pcadvstyle{B}}}
-	\providecommand{\cdv}{\ensuremath{\pcadvstyle{C}}}
-	\providecommand{\ddv}{\ensuremath{\pcadvstyle{D}}}
-	\providecommand{\mdv}{\ensuremath{\pcadvstyle{M}}}
-	\providecommand{\pdv}{\ensuremath{\pcadvstyle{P}}}
-	\providecommand{\rdv}{\ensuremath{\pcadvstyle{R}}}
-	\providecommand{\sdv}{\ensuremath{\pcadvstyle{S}}}
+	\providecommand{\adv}{\ensuremath{\pcadvstyle{A}}\xspace}
+	\providecommand{\bdv}{\ensuremath{\pcadvstyle{B}}\xspace}
+	\providecommand{\cdv}{\ensuremath{\pcadvstyle{C}}\xspace}
+	\providecommand{\ddv}{\ensuremath{\pcadvstyle{D}}\xspace}
+	\providecommand{\mdv}{\ensuremath{\pcadvstyle{M}}\xspace}
+	\providecommand{\pdv}{\ensuremath{\pcadvstyle{P}}\xspace}
+	\providecommand{\rdv}{\ensuremath{\pcadvstyle{R}}\xspace}
+	\providecommand{\sdv}{\ensuremath{\pcadvstyle{S}}\xspace}
 }
 
 \DeclareOption{landau}{
@@ -355,7 +355,7 @@
 \RequirePackage{suffix}
 \RequirePackage{etoolbox}
 \RequirePackage{environ}
-%\RequirePackage{xspace}
+\RequirePackage{xspace}
 \RequirePackage{xkeyval}
 
 \ifpc@advantage


### PR DESCRIPTION
Adversary terms don't have correct spacing when used in text mode. There's no space to the right of them:
<img width="529" alt="Screenshot 2023-11-26 at 12 35 20" src="https://github.com/arnomi/cryptocode/assets/752802/cea07d18-9e14-490d-b0cb-9f983d3d3c25">

This PR puts an `\xspace` after the term. As a result, cryptocode now requires `xspace` as a dependency (which appears to have been the case some time in the past too).