### PR TITLE
docs: Proover, `smallOmega`, and `state`

### DIFF
--- a/cryptocode.dtx
+++ b/cryptocode.dtx
@@ -1479,7 +1479,7 @@
 % |fk| & function key & $\fk$  \\
 % |st| & state & $\st$  \\
 % |state| & state & $\state$  \\
-% |state{myState}| & custom state & $\state{myState}$  
+% |state[myState]| & custom state & $\state[myState]$  
 % \end{tabular}
 % \end{center}
 %

--- a/cryptocode.dtx
+++ b/cryptocode.dtx
@@ -1298,7 +1298,7 @@
 % \begin{center}
 % \begin{tabular}{l l l}
 % \textbf{Command} & \textbf{Description} & \textbf{Result} \\\hline
-% |\prover| & Proover & $\prover$  \\
+% |\prover| & Prover & $\prover$  \\
 % |\verifier| & Verifier & $\verifier$  \\
 % |\nizk| & Non interactive zero knowledge & $\nizk$  \\
 % |\hash| & A hash function & $\hash$  \\

--- a/cryptocode.dtx
+++ b/cryptocode.dtx
@@ -982,6 +982,7 @@
 % |\bigO{n^2}| & Big O(micron) notation & $\bigO{n^2}$  \\
 % |\smallO{n^2}| & small o(micron) notation & $\smallO{n^2}$  \\
 % |\bigOmega{n^2}| & Big Omega notation & $\bigOmega{n^2}$  \\
+% |\smallOmega{n^2}| & small omega notation & $\smallOmega{n^2}$  \\
 % |\bigTheta{n^2}| & Big  Theta & $\bigTheta{n^2}$  \\
 % |\orderOf| & On the order of & $f(n) \orderOf g(n)$
 % \end{tabular}


### PR DESCRIPTION
- Add `\smallOmega` to documentation under Landau option.
- Fix `\state[myState]` instead of `\state{myState}` under Keys option.
- Fix "Prover" instead of "Proover" under Crypto Primitives.